### PR TITLE
Fix NRE when trying to write debug text

### DIFF
--- a/NgrokApi/ApiHttpClient.cs
+++ b/NgrokApi/ApiHttpClient.cs
@@ -113,7 +113,7 @@ namespace NgrokApi
 
         private void WriteDebug(string text)
         {
-            debugStream.WriteLine(text);
+            debugStream?.WriteLine(text);
         }
     }
 }


### PR DESCRIPTION
When `debugStream` is not set then it will be NullReferenceException